### PR TITLE
Add desktop support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,15 @@ once_cell = "1.17.0"
 web-sys = { version = "0.3.61", features = ["Window", "Document", "Element", "HtmlDocument", "Storage", "console"] }
 yazi = "0.1.4"
 wasm-bindgen = "0.2"
+directories = "4.0.1"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+directories = "4.0.1"
 
 [dev-dependencies]
 dioxus = { git = "https://github.com/dioxuslabs/dioxus" }
 dioxus-web = { git = "https://github.com/dioxuslabs/dioxus" }
+
+[features]
+hydrate = []
+ssr = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 mod client_storage;
-// mod memory_storage;
-mod server_storage;
 pub mod storage;
 
-pub use client_storage::use_persistent;
-pub use server_storage::*;
+pub use client_storage::{set_dir_name, set_directory, use_persistent};
 
 pub use once_cell;
 pub use postcard;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,14 +7,12 @@ use std::ops::{Deref, DerefMut};
 
 pub fn serde_to_string<T: Serialize>(value: &T) -> String {
     let serialized = to_allocvec(value).unwrap();
-    println!("serialized: {:?}", serialized.len());
     let compressed = yazi::compress(
         &serialized,
         yazi::Format::Zlib,
         yazi::CompressionLevel::BestSize,
     )
     .unwrap();
-    println!("compressed: {:?}", compressed.len());
     let as_str: String = compressed
         .iter()
         .flat_map(|u| {


### PR DESCRIPTION
Add support for non-wasm and ssr targets. This PR makes it possible to use `dioxus-storage` with desktop and native dioxus renderers