### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Evan Almloff <evanalmloff@gmail.com>"]
 description = "A simple storage library for Dioxus"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/Demonthos/dioxus-storage"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it