### PR TITLE
add cfg guards around exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,10 @@
 mod client_storage;
 mod storage;
 
-pub use client_storage::{set_dir_name, set_directory, use_persistent};
+#[cfg(not(target_arch = "wasm32"))]
+pub use client_storage::{set_dir_name, set_directory};
+
+pub use client_storage::use_persistent;
 
 pub use once_cell;
 pub use postcard;


### PR DESCRIPTION
When testing this out on a web project, I kept getting compilation issues. The lib.rs file was exporting functions that were configured out for me.